### PR TITLE
top-level root nav classes selection from package.json

### DIFF
--- a/packages/cli/src/commands/make-site.tsx
+++ b/packages/cli/src/commands/make-site.tsx
@@ -57,13 +57,15 @@ class Website implements RenderContext {
     graph: Graph;
     schema: Schema;
     prefixes: PrefixTable;
+    roots: ReadonlySet<string>;
 
     readonly outputs: Record<string, string> = {};
 
-    constructor(readonly title: string, readonly baseURL: string) {
+    constructor(readonly title: string, readonly baseURL: string, readonly rootIRIs: ReadonlySet<string>) {
         this.graph = Graph.from(this.dataset);
         this.schema = Schema.decompile(this.dataset, this.graph);
         this.prefixes = new PrefixTable(this.namespaces);
+        this.roots = rootIRIs; 
     }
 
     lookupPrefixedName(iri: string): { readonly prefixLabel: string; readonly localName: string; } | null {
@@ -213,7 +215,7 @@ export default function main(options: Options): void {
     const project = new Project(options.project);
     const icons = project.json.siteOptions?.icons || [];
     const assets = project.json.siteOptions?.assets || {};
-    const context = new Website(project.json.siteOptions?.title || DEFAULT_TITLE, new URL(options.base || project.json.siteOptions?.baseURL || DEFAULT_BASE, DEFAULT_BASE).href);
+    const context = new Website(project.json.siteOptions?.title || DEFAULT_TITLE, new URL(options.base || project.json.siteOptions?.baseURL || DEFAULT_BASE, DEFAULT_BASE).href, project.package.roots);
     const site = new Workspace(project.package.resolve(options.output || project.json.siteOptions?.outDir || "public"));
 
     context.beforecompile();

--- a/packages/cli/src/commands/make-site.tsx
+++ b/packages/cli/src/commands/make-site.tsx
@@ -57,15 +57,15 @@ class Website implements RenderContext {
     graph: Graph;
     schema: Schema;
     prefixes: PrefixTable;
-    roots: ReadonlySet<string>;
 
     readonly outputs: Record<string, string> = {};
+    readonly rootClasses: ReadonlySet<string> | null;
 
-    constructor(readonly title: string, readonly baseURL: string, readonly rootIRIs: ReadonlySet<string>) {
+    constructor(readonly title: string, readonly baseURL: string, rootClasses?: Iterable<string>) {
         this.graph = Graph.from(this.dataset);
         this.schema = Schema.decompile(this.dataset, this.graph);
         this.prefixes = new PrefixTable(this.namespaces);
-        this.roots = rootIRIs; 
+        this.rootClasses = rootClasses ? new Set(rootClasses) : null;
     }
 
     lookupPrefixedName(iri: string): { readonly prefixLabel: string; readonly localName: string; } | null {
@@ -215,7 +215,7 @@ export default function main(options: Options): void {
     const project = new Project(options.project);
     const icons = project.json.siteOptions?.icons || [];
     const assets = project.json.siteOptions?.assets || {};
-    const context = new Website(project.json.siteOptions?.title || DEFAULT_TITLE, new URL(options.base || project.json.siteOptions?.baseURL || DEFAULT_BASE, DEFAULT_BASE).href, project.package.roots);
+    const context = new Website(project.json.siteOptions?.title || DEFAULT_TITLE, new URL(options.base || project.json.siteOptions?.baseURL || DEFAULT_BASE, DEFAULT_BASE).href, project.json.siteOptions?.roots);
     const site = new Workspace(project.package.resolve(options.output || project.json.siteOptions?.outDir || "public"));
 
     context.beforecompile();

--- a/packages/cli/src/model/package.ts
+++ b/packages/cli/src/model/package.ts
@@ -23,14 +23,12 @@ export interface PackageConfig {
     devDependencies?: unknown; // Record<string, string>
 
     ontologies?: unknown, // Record<DocumentUri, string>
-    roots?: unknown, //Array<string>
 }
 
 export class Package extends Workspace {
     private _dependencies?: ReadonlyMap<string, Package | null>;
     private _files?: ReadonlyMap<DocumentUri, TextFile | null>;
     private _json?: PackageConfig;
-    private _roots?: ReadonlySet<string>;
 
     constructor(packagePath: string, readonly containingProject: Project) {
         super(packagePath);
@@ -51,21 +49,8 @@ export class Package extends Workspace {
     get version(): string | undefined {
         return Is.string(this.json.version) ? this.json.version : undefined;
     }
-
-    get roots(): ReadonlySet<string> {
-        return this._roots ??= getRoots(this.json);
-    }
 }
 
-function getRoots(json: PackageConfig): ReadonlySet<string> {
-    const rootIRIs = new Set<string>();
-    if(Array.isArray(json.roots)) {
-        json.roots.forEach( (r) => {
-            rootIRIs.add(r);
-        } );
-    }
-    return rootIRIs;
-}
 function getDependencies(json: PackageConfig, containingProject: Project): Map<string, Package | null> {
     const dependencies = new Map<string, Package | null>();
 

--- a/packages/cli/src/model/package.ts
+++ b/packages/cli/src/model/package.ts
@@ -23,12 +23,14 @@ export interface PackageConfig {
     devDependencies?: unknown; // Record<string, string>
 
     ontologies?: unknown, // Record<DocumentUri, string>
+    roots?: unknown, //Array<string>
 }
 
 export class Package extends Workspace {
     private _dependencies?: ReadonlyMap<string, Package | null>;
     private _files?: ReadonlyMap<DocumentUri, TextFile | null>;
     private _json?: PackageConfig;
+    private _roots?: ReadonlySet<string>;
 
     constructor(packagePath: string, readonly containingProject: Project) {
         super(packagePath);
@@ -49,8 +51,21 @@ export class Package extends Workspace {
     get version(): string | undefined {
         return Is.string(this.json.version) ? this.json.version : undefined;
     }
+
+    get roots(): ReadonlySet<string> {
+        return this._roots ??= getRoots(this.json);
+    }
 }
 
+function getRoots(json: PackageConfig): ReadonlySet<string> {
+    const rootIRIs = new Set<string>();
+    if(Array.isArray(json.roots)) {
+        json.roots.forEach( (r) => {
+            rootIRIs.add(r);
+        } );
+    }
+    return rootIRIs;
+}
 function getDependencies(json: PackageConfig, containingProject: Project): Map<string, Package | null> {
     const dependencies = new Map<string, Package | null>();
 

--- a/packages/cli/src/model/project.ts
+++ b/packages/cli/src/model/project.ts
@@ -30,6 +30,7 @@ export interface SiteConfig {
     assets?: Record<string, string>;
     baseURL?: string;
     outDir?: string;
+    roots?: Array<string>;
 }
 
 export namespace SiteConfig {
@@ -41,7 +42,8 @@ export namespace SiteConfig {
             && (Is.undefined(candidate.icons) || Is.typedArray(candidate.icons, IconConfig.is))
             && (Is.undefined(candidate.assets) || Is.objectLiteral(candidate.assets))
             && (Is.undefined(candidate.baseURL) || Is.string(candidate.baseURL))
-            && (Is.undefined(candidate.outDir) || Is.string(candidate.outDir));
+            && (Is.undefined(candidate.outDir) || Is.string(candidate.outDir))
+            && (Is.undefined(candidate.roots) || Is.typedArray(candidate.roots, Is.string));
     }
 }
 

--- a/packages/explorer-views/src/context.ts
+++ b/packages/explorer-views/src/context.ts
@@ -6,7 +6,7 @@ export interface RenderContext {
     readonly documents: Record<string, TextDocument>;
     readonly graph: Graph;
     readonly schema: Schema;
-    readonly roots: ReadonlySet<string>;
+    readonly rootClasses: ReadonlySet<string> | null;
 
     lookupPrefixedName(iri: string): { readonly prefixLabel: string, readonly localName: string } | null;
 

--- a/packages/explorer-views/src/context.ts
+++ b/packages/explorer-views/src/context.ts
@@ -6,6 +6,7 @@ export interface RenderContext {
     readonly documents: Record<string, TextDocument>;
     readonly graph: Graph;
     readonly schema: Schema;
+    readonly roots: ReadonlySet<string>;
 
     lookupPrefixedName(iri: string): { readonly prefixLabel: string, readonly localName: string } | null;
 

--- a/packages/explorer-views/src/pages/navigation.tsx
+++ b/packages/explorer-views/src/pages/navigation.tsx
@@ -20,8 +20,15 @@ function createTree<T extends Class | Property | Ontology>(items: Iterable<T>, p
                 (tree[parent.value] || (tree[parent.value] = { label: renderRdfTerm(parent, context, options), children: [], open: parent === Rdfs.Resource || parent === Owl.Thing })).children.push(node);
                 hasParents = true;
             }
-            if (!hasParents) {
-                roots.push(node);
+
+            if(context.roots.size > 0) {
+                if(context.roots.has(item.id.value)) {
+                  roots.push(node);
+                 }
+            } else {
+                if (!hasParents) {
+                 roots.push(node);
+                }
             }
         }
     }

--- a/packages/explorer-worker/src/main.tsx
+++ b/packages/explorer-worker/src/main.tsx
@@ -62,13 +62,14 @@ class BackendImpl implements Backend, RenderContext {
     graph: Graph;
     schema: Schema;
     prefixes: PrefixTable;
-    roots: ReadonlySet<string>;
+
+    readonly rootClasses: ReadonlySet<string> | null;
 
     constructor(private readonly frontend: Frontend) {
         this.graph = Graph.from(this.dataset);
         this.schema = Schema.decompile(this.dataset, this.graph);
         this.prefixes = new PrefixTable(this.namespaces);
-        this.roots = new Set();
+        this.rootClasses = null;
     }
 
     lookupPrefixedName(iri: string): { readonly prefixLabel: string; readonly localName: string; } | null {

--- a/packages/explorer-worker/src/main.tsx
+++ b/packages/explorer-worker/src/main.tsx
@@ -62,11 +62,13 @@ class BackendImpl implements Backend, RenderContext {
     graph: Graph;
     schema: Schema;
     prefixes: PrefixTable;
+    roots: ReadonlySet<string>;
 
     constructor(private readonly frontend: Frontend) {
         this.graph = Graph.from(this.dataset);
         this.schema = Schema.decompile(this.dataset, this.graph);
         this.prefixes = new PrefixTable(this.namespaces);
+        this.roots = new Set();
     }
 
     lookupPrefixedName(iri: string): { readonly prefixLabel: string; readonly localName: string; } | null {


### PR DESCRIPTION
Again probably not for merging, but with this change you can set top-level IRIs that can be used for the root in the navigation tree:

```json
{
  "private": true,
  "ontologies": {
    "http://www.w3.org/1999/02/22-rdf-syntax-ns": "vocab/rdf.ttl",
    "http://www.w3.org/2000/01/rdf-schema": "vocab/rdfs.ttl",
    "http://www.w3.org/2002/07/owl": "vocab/owl.ttl",
    "https://brickschema.org/schema/Brick": "vocab/Brick.ttl"
  },
  "roots": [
    "http://www.w3.org/2000/01/rdf-schema#Class",
    "https://brickschema.org/schema/Brick#Class",
    "https://brickschema.org/schema/Brick#EntityProperty"
  ],
  "scripts": {
    "prebuild": "rimraf -g \"./public/**/*\"",
    "build": "npx rdf make explorer",
    "clean": "rimraf -g \"./public/**/*\"",
    "serve": "npx rdf serve"
  },
  "devDependencies": {
    "@rdf-toolkit/cli": "0.1.0",
    "rimraf": "^4.4.1"
  }
}
```

and then after `npx rdf make site`

<img width="1116" alt="Screen Shot 2023-04-24 at 4 47 38 PM" src="https://user-images.githubusercontent.com/315267/234124998-74768da3-3155-447d-bab7-3790b9da24f6.png">

Things that aren't in the tree are still clickable - here's a property

<img width="1131" alt="Screen Shot 2023-04-24 at 4 47 48 PM" src="https://user-images.githubusercontent.com/315267/234125083-2ddd5006-c664-4bc0-8332-b9c60a453622.png">

If you don't have a 'roots' array in package.json, it works as before

A couple of things:
- Entity Properties didn't work the way I expected them too
- This is kind of hacky. For one, it's not good typescript, it's just an array of strings. Second, I had to add an empty element into the BackendImpl in the worker views, which feels like its probably off, but I'm not sure where else to hook up to except the context object
- I haven't added a 'add root' command to the CLI, you have to edit package,json by hand
- I might have broken the 'ontologies' tab

This works without my other patch, and with only Brick set as the root, the site is 1.2gigabytes of HTML.

Rather than not listing all of the other classes in the nav bar, maybe we want to hide them under an 'Other' dropdown? Or make them at least searchable?