### PR TITLE
SSG: use iframe approach

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,10 @@
         "packages/explorer",
         "packages/explorer-site",
         "packages/cli"
-      ]
+      ],
+      "dependencies": {
+        "@rdf-toolkit/cli": "^0.1.0"
+      }
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.18",
@@ -2990,6 +2993,7 @@
       }
     },
     "packages/cli": {
+      "name": "@rdf-toolkit/cli",
       "version": "0.1.0",
       "dependencies": {
         "@rdf-toolkit/iterable": "0.1.0",
@@ -3020,6 +3024,7 @@
       }
     },
     "packages/explorer": {
+      "name": "@rdf-toolkit/explorer",
       "version": "0.1.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.1",
@@ -3031,6 +3036,7 @@
       }
     },
     "packages/explorer-shared": {
+      "name": "@rdf-toolkit/explorer-shared",
       "version": "0.1.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.1",
@@ -3040,6 +3046,7 @@
       }
     },
     "packages/explorer-site": {
+      "name": "@rdf-toolkit/explorer-site",
       "version": "0.1.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.1",
@@ -3051,6 +3058,7 @@
       }
     },
     "packages/explorer-views": {
+      "name": "@rdf-toolkit/explorer-views",
       "version": "0.1.0",
       "dependencies": {
         "@rdf-toolkit/iterable": "0.1.0",
@@ -3069,6 +3077,7 @@
       }
     },
     "packages/explorer-worker": {
+      "name": "@rdf-toolkit/explorer-worker",
       "version": "0.1.0",
       "dependencies": {
         "@rdf-toolkit/iterable": "0.1.0",
@@ -3089,6 +3098,7 @@
       }
     },
     "packages/iterable": {
+      "name": "@rdf-toolkit/iterable",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
@@ -3100,6 +3110,7 @@
       }
     },
     "packages/rdf": {
+      "name": "@rdf-toolkit/rdf",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -3115,6 +3126,7 @@
       }
     },
     "packages/schema": {
+      "name": "@rdf-toolkit/schema",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -3131,6 +3143,7 @@
       }
     },
     "packages/text": {
+      "name": "@rdf-toolkit/text",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -3146,6 +3159,7 @@
       }
     },
     "packages/turtle": {
+      "name": "@rdf-toolkit/turtle",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "build": "npm run build -ws",
     "clean": "npm run clean -ws",
     "test": "npm test -ws --if-present"
+  },
+  "dependencies": {
+    "@rdf-toolkit/cli": "^0.1.0"
   }
 }

--- a/packages/cli/src/commands/make-site.tsx
+++ b/packages/cli/src/commands/make-site.tsx
@@ -18,15 +18,16 @@ import scriptAssetFilePath from "../assets/scripts/site.min.js";
 import { printDiagnosticsAndExitOnError } from "../diagnostics.js";
 import { Project } from "../model/project.js";
 import { TextFile } from "../model/textfile.js";
-import { DiagnosticOptions, MakeOptions, ProjectOptions, SiteOptions } from "../options.js";
+import {
+    DiagnosticOptions,
+    MakeOptions,
+    ProjectOptions,
+    SiteOptions,
+} from "../options.js";
 import { PrefixTable } from "../prefixes.js";
 import { Workspace } from "../workspace.js";
 
-type Options =
-    & DiagnosticOptions
-    & MakeOptions
-    & ProjectOptions
-    & SiteOptions
+type Options = DiagnosticOptions & MakeOptions & ProjectOptions & SiteOptions;
 
 const DEFAULT_TITLE = "RDF Explorer";
 const DEFAULT_BASE = "https://example.com/";
@@ -42,17 +43,19 @@ class Website implements RenderContext {
     readonly diagnostics: DiagnosticBag = DiagnosticBag.create();
     readonly documents: Record<string, TextDocument> = {};
 
-    readonly namespaces: Record<string, string>[] = [{
-        "_": "http://example.com/.well-known/genid/",
-        "dc11": "http://purl.org/dc/elements/1.1/",
-        "dcmitype": "http://purl.org/dc/dcmitype/",
-        "dcterms": "http://purl.org/dc/terms/",
-        "owl": "http://www.w3.org/2002/07/owl#",
-        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "sh": "http://www.w3.org/ns/shacl#",
-        "xsd": "http://www.w3.org/2001/XMLSchema#",
-    }];
+    readonly namespaces: Record<string, string>[] = [
+        {
+            _: "http://example.com/.well-known/genid/",
+            dc11: "http://purl.org/dc/elements/1.1/",
+            dcmitype: "http://purl.org/dc/dcmitype/",
+            dcterms: "http://purl.org/dc/terms/",
+            owl: "http://www.w3.org/2002/07/owl#",
+            rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            rdfs: "http://www.w3.org/2000/01/rdf-schema#",
+            sh: "http://www.w3.org/ns/shacl#",
+            xsd: "http://www.w3.org/2001/XMLSchema#",
+        },
+    ];
 
     graph: Graph;
     schema: Schema;
@@ -61,14 +64,20 @@ class Website implements RenderContext {
     readonly outputs: Record<string, string> = {};
     readonly rootClasses: ReadonlySet<string> | null;
 
-    constructor(readonly title: string, readonly baseURL: string, rootClasses?: Iterable<string>) {
+    constructor(
+        readonly title: string,
+        readonly baseURL: string,
+        rootClasses?: Iterable<string>
+    ) {
         this.graph = Graph.from(this.dataset);
         this.schema = Schema.decompile(this.dataset, this.graph);
         this.prefixes = new PrefixTable(this.namespaces);
         this.rootClasses = rootClasses ? new Set(rootClasses) : null;
     }
 
-    lookupPrefixedName(iri: string): { readonly prefixLabel: string; readonly localName: string; } | null {
+    lookupPrefixedName(
+        iri: string
+    ): { readonly prefixLabel: string; readonly localName: string } | null {
         return this.prefixes.lookup(iri);
     }
 
@@ -77,14 +86,17 @@ class Website implements RenderContext {
         return result ? resolveHref(result, this.baseURL) : undefined;
     }
 
-    beforecompile(): void {
-    }
+    beforecompile(): void {}
 
     compile(file: TextFile): void {
         this.documents[file.documentURI] = file.document;
         const syntaxTree = file.syntaxTree;
         if (this.diagnostics.errors === 0) {
-            const parserState = SyntaxTree.compileTriples(syntaxTree, this.diagnostics, { returnParserState: true });
+            const parserState = SyntaxTree.compileTriples(
+                syntaxTree,
+                this.diagnostics,
+                { returnParserState: true }
+            );
             if (this.diagnostics.errors === 0) {
                 this.dataset.push(parserState.triples);
                 this.namespaces.push(parserState.namespaces);
@@ -107,99 +119,119 @@ class Website implements RenderContext {
             for (const term of terms) {
                 const prefixedName = this.prefixes.lookup(term.value);
                 if (prefixedName) {
-                    this.outputs[term.value] = path.join(prefixedName.prefixLabel, prefixedName.localName);
-                }
-                else {
+                    this.outputs[term.value] = path.join(
+                        prefixedName.prefixLabel,
+                        prefixedName.localName
+                    );
+                } else {
                     const string = term.value;
                     let hash = 0;
                     for (let i = 0; i < string.length; i++) {
                         const char = string.charCodeAt(i);
-                        hash = ((hash << 5) - hash) + char;
+                        hash = (hash << 5) - hash + char;
                         hash = hash & hash;
                     }
-                    this.outputs[term.value] = (hash & ((1 << 31) - 1)).toString().padStart(10, "0");
+                    this.outputs[term.value] = (hash & ((1 << 31) - 1))
+                        .toString()
+                        .padStart(10, "0");
                 }
             }
         }
     }
 }
 
-function renderIndex(context: Website, links: HtmlContent, scripts: HtmlContent, navigation: HtmlContent): HtmlContent {
-    return <html lang="en-US">
-        <head>
-            <meta charset="utf-8" />
-            <title>{context.title}</title>
-            {links}
-            {scripts}
-        </head>
-        <body>
-            <nav>
-                {navigation}
-            </nav>
-            <main>
-                <section>
-                    <h1>{context.title}</h1>
-                </section>
-                <footer>
-                    {renderFooter(context)}
-                </footer>
-            </main>
-        </body>
-    </html>;
+function renderIndex(
+    context: Website,
+    links: HtmlContent,
+    scripts: HtmlContent,
+    navigation: HtmlContent
+): HtmlContent {
+    return (
+        <html lang="en-US">
+            <head>
+                <meta charset="utf-8" />
+                <title>{context.title}</title>
+                {links}
+                {scripts}
+            </head>
+            <body>
+                <nav>{navigation}</nav>
+                <main>
+                    <section>
+                        <h1>{context.title}</h1>
+                    </section>
+                    <footer>{renderFooter(context)}</footer>
+                </main>
+            </body>
+        </html>
+    );
 }
 
-function render404(context: Website, links: HtmlContent, scripts: HtmlContent, navigation: HtmlContent): HtmlContent {
-    return <html lang="en-US">
-        <head>
-            <meta charset="utf-8" />
-            <title>Page not found &ndash; {context.title}</title>
-            {links}
-            {scripts}
-        </head>
-        <body>
-            <nav>
-                {navigation}
-            </nav>
-            <main>
-                <section>
-                    <h1>Page not found</h1>
-                    <p>We are sorry, the page you requested cannot be found.</p>
-                    <p>The URL may be misspelled or the page you're looking for is no longer available.</p>
-                </section>
-                <footer>
-                    {renderFooter(context)}
-                </footer>
-            </main>
-        </body>
-    </html>;
+function render404(
+    context: Website,
+    links: HtmlContent,
+    scripts: HtmlContent,
+    navigation: HtmlContent
+): HtmlContent {
+    return (
+        <html lang="en-US">
+            <head>
+                <meta charset="utf-8" />
+                <title>Page not found &ndash; {context.title}</title>
+                {links}
+                {scripts}
+            </head>
+            <body>
+                <nav>{navigation}</nav>
+                <main>
+                    <section>
+                        <iframe id="pageIframe"></iframe>
+                    </section>
+                    <footer>{renderFooter(context)}</footer>
+                </main>
+            </body>
+        </html>
+    );
 }
 
-function renderPage(iri: string, context: Website, links: HtmlContent, scripts: HtmlContent, navigation: HtmlContent): HtmlContent {
-    const subject: IRIOrBlankNode = iri.startsWith("http://example.com/.well-known/genid/")
-        ? BlankNode.create(iri.slice("http://example.com/.well-known/genid/".length))
+function renderPage(
+    iri: string,
+    context: Website,
+    links: HtmlContent,
+    scripts: HtmlContent
+): HtmlContent {
+    const subject: IRIOrBlankNode = iri.startsWith(
+        "http://example.com/.well-known/genid/"
+    )
+        ? BlankNode.create(
+              iri.slice("http://example.com/.well-known/genid/".length)
+          )
         : IRI.create(iri);
 
     const prefixedName = context.lookupPrefixedName(subject.value);
-    const title = prefixedName ? prefixedName.prefixLabel + ":" + prefixedName.localName : "<" + subject.value + ">";
+    const title = prefixedName
+        ? prefixedName.prefixLabel + ":" + prefixedName.localName
+        : "<" + subject.value + ">";
 
-    const main = renderMain(subject, iri in context.documents ? context.documents[iri] : null, context);
+    const main = renderMain(
+        subject,
+        iri in context.documents ? context.documents[iri] : null,
+        context
+    );
 
-    return <html lang="en-US">
-        <head>
-            <meta charset="utf-8" />
-            <title>{title} &ndash; {context.title}</title>
-            {links}
-            {scripts}
-        </head>
-        <body>
-            <nav>
-                {navigation}
-            </nav>
-            <main>
-                {main}
-            </main>
-        </body>
-    </html>;
+    return (
+        <html lang="en-US">
+            <head>
+                <meta charset="utf-8" />
+                <title>
+                    {title} &ndash; {context.title}
+                </title>
+                {links}
+                {scripts}
+            </head>
+            <body>{main}</body>
+        </html>
+    );
 }
 
 function resolveHref(url: string, base: string): string {
@@ -215,8 +247,19 @@ export default function main(options: Options): void {
     const project = new Project(options.project);
     const icons = project.json.siteOptions?.icons || [];
     const assets = project.json.siteOptions?.assets || {};
-    const context = new Website(project.json.siteOptions?.title || DEFAULT_TITLE, new URL(options.base || project.json.siteOptions?.baseURL || DEFAULT_BASE, DEFAULT_BASE).href, project.json.siteOptions?.roots);
-    const site = new Workspace(project.package.resolve(options.output || project.json.siteOptions?.outDir || "public"));
+    const context = new Website(
+        project.json.siteOptions?.title || DEFAULT_TITLE,
+        new URL(
+            options.base || project.json.siteOptions?.baseURL || DEFAULT_BASE,
+            DEFAULT_BASE
+        ).href,
+        project.json.siteOptions?.roots
+    );
+    const site = new Workspace(
+        project.package.resolve(
+            options.output || project.json.siteOptions?.outDir || "public"
+        )
+    );
 
     context.beforecompile();
     for (const fileSet of project.files.values()) {
@@ -229,33 +272,88 @@ export default function main(options: Options): void {
 
     printDiagnosticsAndExitOnError(project.diagnostics, options);
 
-    const links = <>
-        {icons.map(iconConfig => <link rel="icon" type={iconConfig.type} sizes={iconConfig.sizes} href={resolveHref(path.basename(iconConfig.asset), context.baseURL)} />)}
-        <link rel="stylesheet" href={resolveHref(CSS_FILE_NAME, context.baseURL)} />
-    </>;
+    const links = (
+        <>
+            {icons.map((iconConfig) => (
+                <link
+                    rel="icon"
+                    type={iconConfig.type}
+                    sizes={iconConfig.sizes}
+                    href={resolveHref(
+                        path.basename(iconConfig.asset),
+                        context.baseURL
+                    )}
+                />
+            ))}
+            <link
+                rel="stylesheet"
+                href={resolveHref(CSS_FILE_NAME, context.baseURL)}
+            />
+        </>
+    );
 
-    const scripts = <>
-        <script src={resolveHref(SCRIPT_FILE_NAME, context.baseURL)}></script>
-    </>;
+    const scripts = (
+        <>
+            <script
+                src={resolveHref(SCRIPT_FILE_NAME, context.baseURL)}
+            ></script>
+        </>
+    );
 
     const navigation = renderNavigation(context.title, context);
 
-    site.write(CSS_FILE_NAME, fs.readFileSync(path.format({ ...path.parse(moduleFilePath), base: "", ext: ".css" })));
-    site.write(FONT_FILE_NAME, fs.readFileSync(path.resolve(modulePath, fontAssetFilePath)));
-    site.write(SCRIPT_FILE_NAME, fs.readFileSync(path.resolve(modulePath, scriptAssetFilePath)));
+    site.write(
+        CSS_FILE_NAME,
+        fs.readFileSync(
+            path.format({
+                ...path.parse(moduleFilePath),
+                base: "",
+                ext: ".css",
+            })
+        )
+    );
+    site.write(
+        FONT_FILE_NAME,
+        fs.readFileSync(path.resolve(modulePath, fontAssetFilePath))
+    );
+    site.write(
+        SCRIPT_FILE_NAME,
+        fs.readFileSync(path.resolve(modulePath, scriptAssetFilePath))
+    );
 
     for (const iconConfig of icons) {
-        site.write(path.basename(iconConfig.asset), project.package.read(iconConfig.asset));
+        site.write(
+            path.basename(iconConfig.asset),
+            project.package.read(iconConfig.asset)
+        );
     }
 
     for (const assetPath in assets) {
         site.write(assets[assetPath], project.package.read(assetPath));
     }
 
-    site.write(INDEX_FILE_NAME, Buffer.from("<!DOCTYPE html>\n" + renderHTML(renderIndex(context, links, scripts, navigation))));
-    site.write(ERROR_FILE_NAME, Buffer.from("<!DOCTYPE html>\n" + renderHTML(render404(context, links, scripts, navigation))));
+    site.write(
+        INDEX_FILE_NAME,
+        Buffer.from(
+            "<!DOCTYPE html>\n" +
+                renderHTML(renderIndex(context, links, scripts, navigation))
+        )
+    );
+    site.write(
+        ERROR_FILE_NAME,
+        Buffer.from(
+            "<!DOCTYPE html>\n" +
+                renderHTML(render404(context, links, scripts, navigation))
+        )
+    );
 
     for (const iri in context.outputs) {
-        site.write(context.outputs[iri] + ".html", Buffer.from("<!DOCTYPE html>\n" + renderHTML(renderPage(iri, context, links, scripts, navigation))));
+        site.write(
+            context.outputs[iri] + ".html",
+            Buffer.from(
+                "<!DOCTYPE html>\n" +
+                    renderHTML(renderPage(iri, context, links, scripts))
+            )
+        );
     }
 }

--- a/packages/cli/src/main.css
+++ b/packages/cli/src/main.css
@@ -21,6 +21,19 @@ body {
     padding: 0;
 }
 
+html, 
+body,
+iframe,
+body > main  {
+    height: 100%;
+}
+
+iframe {
+    width: 100%;
+    max-width: 100%;
+    border: none;
+}
+
 a {
     color: var(--base0A);
     text-decoration: none;

--- a/packages/explorer-site/src/main.ts
+++ b/packages/explorer-site/src/main.ts
@@ -7,11 +7,33 @@ window.onclick = function (ev) {
             if (!rel) {
                 ev.preventDefault();
                 if (href) {
-                    window.location.href = href;
+                    window.location.hash = href;
                 }
             }
             break;
         }
         target = target.parentElement;
     }
-}
+};
+
+document.addEventListener("DOMContentLoaded", function () {
+    const iframeElement = document.getElementById("pageIframe");
+
+    if (iframeElement) {
+        window.onload = function () {
+            iframeElement.setAttribute(
+                "src",
+                window.location.hash.substring(1)
+            );
+        };
+
+        window.addEventListener("hashchange", function () {
+            iframeElement.setAttribute(
+                "src",
+                window.location.hash.substring(1)
+            );
+        });
+
+        window.dispatchEvent(new Event("hashchange"));
+    }
+});


### PR DESCRIPTION
In this pull request, we attempted to reduce the build size of our statically generated website by implementing an iframe approach. Specifically, we added a sidebar to the index page only and imported each content page through an iframe on the index page without the sidebar. We used a hash parameter in the URL to determine which page to import into the iframe.

However, after implementing this approach, we did not see significant improvements in build size. In fact, with our internal ttl file, the build size is still at 10GB and it takes 7 minutes to build on a local machine with M1 Pro Max silicon.

[@epaulson](https://github.com/epaulson) [@ektrah](https://github.com/ektrah) Please let me know if you notice any issues with my approach. From our perspective, it is identical to this one: [#9](https://github.com/ektrah/rdf-toolkit/pull/9).